### PR TITLE
Config propogation from gqlserver to graphql-go

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -68,6 +68,7 @@ type Schema struct {
 	logger                log.Logger
 	useStringDescriptions bool
 	disableIntrospection  bool
+	isPanicLogEnabled     bool
 }
 
 // SchemaOpt is an option to pass to ParseSchema or MustParseSchema.
@@ -148,6 +149,19 @@ func (s *Schema) Validate(queryString string, variables map[string]interface{}) 
 		return true, []*errors.QueryError{qErr}
 	}
 	return false, validation.Validate(s.schema, doc, variables, s.maxDepth)
+}
+
+//EnablePanicLogging enables query info logging if panic occurs
+func (s *Schema) EnablePanicLogging() {
+	s.isPanicLogEnabled = true
+	s.logger = getLogger(s)
+}
+
+func getLogger(s *Schema) log.Logger {
+	if s != nil && s.isPanicLogEnabled {
+		return &log.CustomLogger{true}
+	}
+	return &log.DefaultLogger{}
 }
 
 // Exec executes the given query with the schema's resolver. It panics if the schema was created

--- a/log/log.go
+++ b/log/log.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"runtime"
 )
@@ -19,5 +20,24 @@ func (l *DefaultLogger) LogPanic(_ context.Context, value interface{}, info stri
 	const size = 64 << 10
 	buf := make([]byte, size)
 	buf = buf[:runtime.Stack(buf, false)]
-	log.Printf("graphql: panic occurred: %v\n%s\n\n%s", value, buf, info)
+		log.Printf("graphql: panic occurred: %v\n%s", value, buf)
 }
+
+// CustomLogger is the custom logger for use with gqlserver custome config to log panics that occur during query execution
+type CustomLogger struct{
+	VerbosePanicLog bool
+}
+
+// LogPanic is used to log recovered panic values that occur during query execution
+func (l *CustomLogger) LogPanic(_ context.Context, value interface{}, info string) {
+	const size = 64 << 10
+	buf := make([]byte, size)
+	buf = buf[:runtime.Stack(buf, false)]
+	msg := fmt.Sprintf("graphql: panic occurred: %v\n%s", value, buf)
+	if l.VerbosePanicLog {
+		msg = fmt.Sprintf("%s\n\n%s", msg, info)
+	}
+
+	log.Printf(msg)
+}
+


### PR DESCRIPTION
Through this PR I intend to introduce the following changes: 

1. Added method `EnablePanicLogging` which propogate the config from gqlserver app 
2. Create a custom logger which has a field corresponding to config from gqlserver. This field is set in above method to true. When set to true the logs will contain detailed info on query and variables over and above the stack trace from panic otherwise logs will contain just the stack trace.
3. `CustomLogger` implements interface `Logger` and overrided method `LogPanic`